### PR TITLE
Make CI's copyright lawyers happy

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -51,6 +51,10 @@ Files: editor/sublime/LSP.sublime-settings
 Copyright: Copyright © SixtyFPS GmbH <info@slint-ui.com>
 License: GPL-3.0-only OR LicenseRef-Slint-commercial
 
+Files: editor/tree-sitter-slint/binding.gyp
+Copyright: Copyright © SixtyFPS GmbH <info@slint-ui.com>
+License: GPL-3.0-only OR LicenseRef-Slint-commercial
+
 Files: tools/online_editor/*.html tools/online_editor/*.json
 Copyright: Copyright © SixtyFPS GmbH <info@slint-ui.com>
 License: GPL-3.0-only OR LicenseRef-Slint-commercial

--- a/xtask/src/license_headers_check.rs
+++ b/xtask/src/license_headers_check.rs
@@ -263,6 +263,8 @@ enum LicenseLocation {
 lazy_static! {
     // cspell:disable
     static ref LICENSE_LOCATION_FOR_FILE: Vec<(regex::Regex, LicenseLocation)> = [
+        ("^editor/tree-sitter-slint/binding.gyp$", LicenseLocation::NoLicense), // liberal license
+        ("^editor/tree-sitter-slint/queries/.*", LicenseLocation::NoLicense), // liberal license
         ("^helper_crates/const-field-offset/.*", LicenseLocation::NoLicense), // liberal license
         ("^helper_crates/document-features/.*", LicenseLocation::NoLicense), // liberal license
         (".+webpack\\..+\\.js$", LicenseLocation::NoLicense),


### PR DESCRIPTION
Sorry, I forgot about this PR till reading the announcement of some tree-sitter based diff tool yesterday!

Here is the promised patch that should make the Slint CI happy with your tree-sitter change.

Feel free to change this to keep yourself as copyright holder! I used slint, because that is what you used in the grammar and I wanted to stay consistent within the PR.

Thanks for working on this! I really like tree-sitter;-)